### PR TITLE
Return txhash with upload file and create bucket ipc commands

### DIFF
--- a/cmd/akavecli/ipc.go
+++ b/cmd/akavecli/ipc.go
@@ -49,7 +49,7 @@ var (
 
 	ipcBucketDeleteCmd = &cobra.Command{
 		Use:   "delete",
-		Short: "Removes a bucket",
+		Short: "Removes a bucket (Note: Bucket must be empty)",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return NewCmdParamsError(fmt.Sprintf("create bucket command expects exactly 1 argument [bucket name]; got %d", len(args)))
@@ -218,7 +218,7 @@ func cmdCreateBucketIPC(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("failed to create bucket: %w", err)
 	}
 
-	cmd.PrintErrf("Bucket created: ID=%s, CreatedAt=%s\n", result.ID, result.CreatedAt)
+	cmd.PrintErrf("Bucket created: ID=%s, CreatedAt=%s, TxHash=%s\n", result.ID, result.CreatedAt, result.TxHash)
 
 	return nil
 }
@@ -430,7 +430,7 @@ func cmdFileUploadIPC(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("failed to upload file: %w", err)
 	}
 
-	cmd.PrintErrf("File uploaded successfully: Name=%s, RootCID=%s\n", fileName, fileUpload.RootCID)
+	cmd.PrintErrf("File uploaded successfully: Name=%s, RootCID=%s, TxHash=%s\n", fileName, fileUpload.RootCID, fileUpload.TxHash)
 
 	return nil
 }

--- a/sdk/model.go
+++ b/sdk/model.go
@@ -14,6 +14,7 @@ import (
 type BucketCreateResult struct {
 	ID        string
 	CreatedAt time.Time
+	TxHash    string
 }
 
 // Bucket is a bucket.
@@ -59,6 +60,7 @@ type FileUpload struct {
 	FileName   string
 	FileSize   int64
 	Blocks     []FileBlock
+	TxHash     string
 }
 
 // FileDownload represents a file download and some metadata.

--- a/sdk/sdk_ipc.go
+++ b/sdk/sdk_ipc.go
@@ -51,6 +51,8 @@ func (sdk *IPC) CreateBucket(ctx context.Context, name string) (_ *BucketCreateR
 		return &BucketCreateResult{}, errSDK.Wrap(err)
 	}
 
+	txHash := tx.Hash().String()
+
 	if err := sdk.ipc.WaitForTx(ctx, tx.Hash()); err != nil {
 		return &BucketCreateResult{}, errSDK.Wrap(err)
 	}
@@ -63,6 +65,7 @@ func (sdk *IPC) CreateBucket(ctx context.Context, name string) (_ *BucketCreateR
 	return &BucketCreateResult{
 		ID:        hex.EncodeToString(bucket.Id[:]),
 		CreatedAt: time.Unix(bucket.CreatedAt.Int64(), 0),
+		TxHash:    txHash,
 	}, nil
 }
 
@@ -273,6 +276,8 @@ func (sdk *IPC) CreateFileUpload(ctx context.Context, bucketName string, fileNam
 		return FileUpload{}, errSDK.Wrap(err)
 	}
 
+	txHash := tx.Hash().String()
+
 	res, err := sdk.client.FileUploadCreate(ctx, req)
 	if err != nil {
 		return FileUpload{}, errSDK.Wrap(err)
@@ -299,6 +304,7 @@ func (sdk *IPC) CreateFileUpload(ctx context.Context, bucketName string, fileNam
 		FileName:   fileName,
 		FileSize:   fileSize,
 		Blocks:     blocks,
+		TxHash:     txHash,
 	}, nil
 }
 


### PR DESCRIPTION
Changes:

1. Return on-chain transaction hash with IPC commands: `create bucket`, `upload file` for better visibility 
2. Added note ` (Note: Bucket must be empty)` in sdk command help