### PR TITLE
Potential Memory Optimization in parseErrorsToHashes()

### DIFF
--- a/private/ipc/errors.go
+++ b/private/ipc/errors.go
@@ -79,7 +79,7 @@ func parseErrorsToHashes() []string {
 		"BlockAlreadyExists()", "BlockInvalid()", "BlockNonexists()", "InvalidArrayLength(uint256 cidsLength, uint256 sizesLength)", "InvalidFileBlocksCount()",
 		"InvalidLastBlockSize()", "InvalidEncodedSize()", "InvalidFileCID()", "IndexMismatch()", "NoPolicy()"}
 
-	errHashes := make([]string, 0)
+	errHashes := make([]string, len(errorsContract))
 
 	for _, errC := range errorsContract {
 		hash := crypto.Keccak256([]byte(errC))


### PR DESCRIPTION
Since we know the exact size needed for the slice, we should pre-allocate it to avoid unnecessary slice growth operations.