### PR TITLE
cmd/akavecli: enable erasure coding by default

### DIFF
--- a/cmd/akavecli/main.go
+++ b/cmd/akavecli/main.go
@@ -107,14 +107,14 @@ var (
 		RunE:  cmdListBuckets,
 	}
 
-	nodeRPCAddress    string
-	privateKey        string
-	encryptionKey     string
-	maxConcurrency    int
-	blockPartSize     int64
-	useConnectionPool bool
-	useErasureCoding  bool
-	filecoinFlag      bool
+	nodeRPCAddress       string
+	privateKey           string
+	encryptionKey        string
+	maxConcurrency       int
+	blockPartSize        int64
+	useConnectionPool    bool
+	disableErasureCoding bool
+	filecoinFlag         bool
 
 	// tracing.
 	mon = monkit.Package()
@@ -179,7 +179,7 @@ func initFlags() {
 
 	for _, cmd := range []*cobra.Command{ipcFileUploadCmd, ipcFileDownloadCmd, streamingFileUploadCmd, streamingFileDownloadCmd} {
 		cmd.Flags().StringVarP(&encryptionKey, "encryption-key", "e", "", "Encryption key for encrypting file data")
-		cmd.Flags().BoolVar(&useErasureCoding, "erasure-coding", false, "Use erasure coding")
+		cmd.Flags().BoolVar(&disableErasureCoding, "disable-erasure-coding", false, "Do not use erasure coding")
 	}
 }
 
@@ -369,7 +369,7 @@ func encryptionKeyBytes() ([]byte, error) {
 }
 
 func parityBlocks() int {
-	if useErasureCoding {
+	if !disableErasureCoding {
 		return 16
 	}
 	return 0

--- a/cmd/akavecli/main_test.go
+++ b/cmd/akavecli/main_test.go
@@ -713,13 +713,13 @@ func TestIPCFileUploadCommand(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:           "File upload successfully",
-			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress},
+			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--disable-erasure-coding"},
 			expectedOutput: []string{fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file))},
 			expectError:    false,
 		},
 		{
-			name:           "File upload successfully without erasure coding",
-			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file2, "--node-address", nodeAddress, "--disable-erasure-coding"},
+			name:           "File upload successfully with erasure coding",
+			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file2, "--node-address", nodeAddress},
 			expectedOutput: []string{fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file2))},
 			expectError:    false,
 		},
@@ -771,13 +771,13 @@ func TestIPCFileUploadCommandWithEncryption(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:           "File upload successfully",
-			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--encryption-key", encKey},
+			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"},
 			expectedOutput: []string{fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file))},
 			expectError:    false,
 		},
 		{
-			name:           "File upload successfully without erasure coding",
-			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file2, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"},
+			name:           "File upload successfully with erasure coding",
+			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file2, "--node-address", nodeAddress, "--encryption-key", encKey},
 			expectedOutput: []string{fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file2))},
 			expectError:    false,
 		},
@@ -814,7 +814,7 @@ func TestStreamingFileUploadCommand(t *testing.T) {
 	testCases := []testCase{
 		{
 			name: "File uploaded successfully",
-			args: []string{"files-streaming", "upload", bucketName, file, "--node-address", nodeAddress},
+			args: []string{"files-streaming", "upload", bucketName, file, "--node-address", nodeAddress, "--disable-erasure-coding"},
 			expectedOutput: []string{
 				fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file)),
 				"RootCID=",
@@ -824,8 +824,8 @@ func TestStreamingFileUploadCommand(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "File uploaded successfully without erasure coding",
-			args: []string{"files-streaming", "upload", bucketName, file2, "--node-address", nodeAddress, "--disable-erasure-coding"},
+			name: "File uploaded successfully with erasure coding",
+			args: []string{"files-streaming", "upload", bucketName, file2, "--node-address", nodeAddress},
 			expectedOutput: []string{
 				fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file2)),
 				"RootCID=",
@@ -879,7 +879,7 @@ func TestStreamingFileUploadCommandWithEncryption(t *testing.T) {
 	testCases := []testCase{
 		{
 			name: "File uploaded successfully",
-			args: []string{"files-streaming", "upload", bucketName, file, "--node-address", nodeAddress, "--encryption-key", encKey},
+			args: []string{"files-streaming", "upload", bucketName, file, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"},
 			expectedOutput: []string{
 				fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file)),
 				"RootCID=",
@@ -889,8 +889,8 @@ func TestStreamingFileUploadCommandWithEncryption(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "File upload successfully without erasure coding",
-			args: []string{"files-streaming", "upload", bucketName, file2, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"},
+			name: "File upload successfully with erasure coding",
+			args: []string{"files-streaming", "upload", bucketName, file2, "--node-address", nodeAddress, "--encryption-key", encKey},
 			expectedOutput: []string{
 				fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file2)),
 				"RootCID=",
@@ -989,7 +989,7 @@ func TestIPCFileDownloadCommand(t *testing.T) {
 	}
 }
 
-func TestIPCFileDownloadCommandWithoutErasureCoding(t *testing.T) {
+func TestIPCFileDownloadCommandWithErasureCoding(t *testing.T) {
 	nodeAddress := PickNodeRPCAddress(t)
 	privateKey := PickPrivateKey(t)
 
@@ -1000,7 +1000,7 @@ func TestIPCFileDownloadCommandWithoutErasureCoding(t *testing.T) {
 	file, err := createTempFile(t, 2*memory.MB.ToInt64())
 	assert.NoError(t, err)
 
-	_, _, err = captureCobraOutput(rootCmd, []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--disable-erasure-coding"})
+	_, _, err = captureCobraOutput(rootCmd, []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress})
 	assert.NoError(t, err)
 
 	tempDir, err := os.MkdirTemp("", "test-download")
@@ -1013,7 +1013,7 @@ func TestIPCFileDownloadCommandWithoutErasureCoding(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:           "File download successfully",
-			args:           []string{"ipc", "file", "download", "--private-key", privateKey, bucketName, filepath.Base(file), tempDir, "--node-address", nodeAddress, "--disable-erasure-coding"},
+			args:           []string{"ipc", "file", "download", "--private-key", privateKey, bucketName, filepath.Base(file), tempDir, "--node-address", nodeAddress},
 			expectedOutput: []string{fmt.Sprintf("File downloaded successfully: Name=%s", filepath.Base(file))},
 			expectError:    false,
 		},
@@ -1083,7 +1083,7 @@ func TestIPCFileDownloadCommandWithEncryption(t *testing.T) {
 	}
 }
 
-func TestIPCFileDownloadCommandWithEncryptionAndWithoutErasureCoding(t *testing.T) {
+func TestIPCFileDownloadCommandWithEncryptionAndWithErasureCoding(t *testing.T) {
 	nodeAddress := PickNodeRPCAddress(t)
 	privateKey := PickPrivateKey(t)
 
@@ -1094,7 +1094,7 @@ func TestIPCFileDownloadCommandWithEncryptionAndWithoutErasureCoding(t *testing.
 	file, err := createTempFile(t, 2*memory.MB.ToInt64())
 	assert.NoError(t, err)
 
-	_, _, err = captureCobraOutput(rootCmd, []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"})
+	_, _, err = captureCobraOutput(rootCmd, []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--encryption-key", encKey})
 	assert.NoError(t, err)
 
 	tempDir, err := os.MkdirTemp("", "test-download")
@@ -1107,7 +1107,7 @@ func TestIPCFileDownloadCommandWithEncryptionAndWithoutErasureCoding(t *testing.
 	testCases := []testCase{
 		{
 			name:           "File download successfully",
-			args:           []string{"ipc", "file", "download", "--private-key", privateKey, bucketName, filepath.Base(file), tempDir, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"},
+			args:           []string{"ipc", "file", "download", "--private-key", privateKey, bucketName, filepath.Base(file), tempDir, "--node-address", nodeAddress, "--encryption-key", encKey},
 			expectedOutput: []string{fmt.Sprintf("File downloaded successfully: Name=%s", filepath.Base(file))},
 			expectError:    false,
 		},

--- a/cmd/akavecli/main_test.go
+++ b/cmd/akavecli/main_test.go
@@ -1083,7 +1083,7 @@ func TestIPCFileDownloadCommandWithEncryption(t *testing.T) {
 	}
 }
 
-func TestIPCFileDownloadCommandWithEncryptionAndWithErasureCoding(t *testing.T) {
+func TestIPCFileDownloadCommandWithEncryptionAndErasureCoding(t *testing.T) {
 	nodeAddress := PickNodeRPCAddress(t)
 	privateKey := PickPrivateKey(t)
 

--- a/cmd/akavecli/main_test.go
+++ b/cmd/akavecli/main_test.go
@@ -718,8 +718,8 @@ func TestIPCFileUploadCommand(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name:           "File upload successfully with erasure coding",
-			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file2, "--node-address", nodeAddress, "--erasure-coding"},
+			name:           "File upload successfully without erasure coding",
+			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file2, "--node-address", nodeAddress, "--disable-erasure-coding"},
 			expectedOutput: []string{fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file2))},
 			expectError:    false,
 		},
@@ -776,8 +776,8 @@ func TestIPCFileUploadCommandWithEncryption(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name:           "File upload successfully with erasure coding",
-			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file2, "--node-address", nodeAddress, "--encryption-key", encKey, "--erasure-coding"},
+			name:           "File upload successfully without erasure coding",
+			args:           []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file2, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"},
 			expectedOutput: []string{fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file2))},
 			expectError:    false,
 		},
@@ -824,8 +824,8 @@ func TestStreamingFileUploadCommand(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "File uploaded successfully with erasure coding",
-			args: []string{"files-streaming", "upload", bucketName, file2, "--node-address", nodeAddress, "--erasure-coding"},
+			name: "File uploaded successfully without erasure coding",
+			args: []string{"files-streaming", "upload", bucketName, file2, "--node-address", nodeAddress, "--disable-erasure-coding"},
 			expectedOutput: []string{
 				fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file2)),
 				"RootCID=",
@@ -889,8 +889,8 @@ func TestStreamingFileUploadCommandWithEncryption(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "File upload successfully with erasure coding",
-			args: []string{"files-streaming", "upload", bucketName, file2, "--node-address", nodeAddress, "--encryption-key", encKey, "--erasure-coding"},
+			name: "File upload successfully without erasure coding",
+			args: []string{"files-streaming", "upload", bucketName, file2, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"},
 			expectedOutput: []string{
 				fmt.Sprintf("File uploaded successfully: Name=%s", filepath.Base(file2)),
 				"RootCID=",
@@ -989,7 +989,7 @@ func TestIPCFileDownloadCommand(t *testing.T) {
 	}
 }
 
-func TestIPCFileDownloadCommandWithErasureCoding(t *testing.T) {
+func TestIPCFileDownloadCommandWithoutErasureCoding(t *testing.T) {
 	nodeAddress := PickNodeRPCAddress(t)
 	privateKey := PickPrivateKey(t)
 
@@ -1000,7 +1000,7 @@ func TestIPCFileDownloadCommandWithErasureCoding(t *testing.T) {
 	file, err := createTempFile(t, 2*memory.MB.ToInt64())
 	assert.NoError(t, err)
 
-	_, _, err = captureCobraOutput(rootCmd, []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--erasure-coding"})
+	_, _, err = captureCobraOutput(rootCmd, []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--disable-erasure-coding"})
 	assert.NoError(t, err)
 
 	tempDir, err := os.MkdirTemp("", "test-download")
@@ -1013,7 +1013,7 @@ func TestIPCFileDownloadCommandWithErasureCoding(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:           "File download successfully",
-			args:           []string{"ipc", "file", "download", "--private-key", privateKey, bucketName, filepath.Base(file), tempDir, "--node-address", nodeAddress, "--erasure-coding"},
+			args:           []string{"ipc", "file", "download", "--private-key", privateKey, bucketName, filepath.Base(file), tempDir, "--node-address", nodeAddress, "--disable-erasure-coding"},
 			expectedOutput: []string{fmt.Sprintf("File downloaded successfully: Name=%s", filepath.Base(file))},
 			expectError:    false,
 		},
@@ -1083,7 +1083,7 @@ func TestIPCFileDownloadCommandWithEncryption(t *testing.T) {
 	}
 }
 
-func TestIPCFileDownloadCommandWithEncryptionAndErasureCoding(t *testing.T) {
+func TestIPCFileDownloadCommandWithEncryptionAndWithoutErasureCoding(t *testing.T) {
 	nodeAddress := PickNodeRPCAddress(t)
 	privateKey := PickPrivateKey(t)
 
@@ -1094,7 +1094,7 @@ func TestIPCFileDownloadCommandWithEncryptionAndErasureCoding(t *testing.T) {
 	file, err := createTempFile(t, 2*memory.MB.ToInt64())
 	assert.NoError(t, err)
 
-	_, _, err = captureCobraOutput(rootCmd, []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--encryption-key", encKey, "--erasure-coding"})
+	_, _, err = captureCobraOutput(rootCmd, []string{"ipc", "file", "upload", "--private-key", privateKey, bucketName, file, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"})
 	assert.NoError(t, err)
 
 	tempDir, err := os.MkdirTemp("", "test-download")
@@ -1107,7 +1107,7 @@ func TestIPCFileDownloadCommandWithEncryptionAndErasureCoding(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:           "File download successfully",
-			args:           []string{"ipc", "file", "download", "--private-key", privateKey, bucketName, filepath.Base(file), tempDir, "--node-address", nodeAddress, "--encryption-key", encKey, "--erasure-coding"},
+			args:           []string{"ipc", "file", "download", "--private-key", privateKey, bucketName, filepath.Base(file), tempDir, "--node-address", nodeAddress, "--encryption-key", encKey, "--disable-erasure-coding"},
 			expectedOutput: []string{fmt.Sprintf("File downloaded successfully: Name=%s", filepath.Base(file))},
 			expectError:    false,
 		},


### PR DESCRIPTION
This pull request includes changes to the `akavecli` command-line interface to update the handling of erasure coding. The main change is the renaming of the flag from `erasure-coding` to `disable-erasure-coding` to better reflect its functionality as now erasure coding is enabled by deafult