### PR TITLE
docs: explain soft delete vs hard delete behaviour in IPC SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Used in IPC endpoint FileDownloadCreate.
 | `Download` | Using the receipt returned from `CreateFileDownload` endpoint downloads the file by blocks, previously fetches peer block addresses of blocks                                                |
 | `FileDelete` | Hard delete (with all blocks) a specific file by its name and bucket's name.                                                                                                                 |
 
-> **Note on delete behaviour**: "Soft delete" removes the bucket or file metadata from the smart contract but does not immediately purge the underlying data blocks from storage nodes. `FileDelete` performs a hard delete, removing both the metadata and all associated data blocks.
+> **Note on delete behaviour**: "Soft delete" removes the bucket or file metadata from the smart contract but does not immediately purge the underlying data blocks from storage nodes. `FileDelete` performs a hard delete for the file record, removing the file metadata and its associated block records from the smart contract.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Used in IPC endpoint FileDownloadCreate.
 | `Download` | Using the receipt returned from `CreateFileDownload` endpoint downloads the file by blocks, previously fetches peer block addresses of blocks                                                |
 | `FileDelete` | Hard delete (with all blocks) a specific file by its name and bucket's name.                                                                                                                 |
 
+> **Note on delete behaviour**: "Soft delete" removes the bucket or file metadata from the smart contract but does not immediately purge the underlying data blocks from storage nodes. `FileDelete` performs a hard delete, removing both the metadata and all associated data blocks.
+
 <br>
 
 # Akave CLI


### PR DESCRIPTION
Closes #44

The IPC SDK table referred to "soft delete" for DeleteBucket without
explaining what this means or how it differs from a hard delete.

This change adds a note clarifying the difference between soft delete
(metadata removal only) and hard delete (metadata + data blocks).