### PR TITLE
docs: add Ubuntu Go installation steps with required sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Whether you're building a new integration or managing data across nodes, this SD
 ## Build and test instructions
 Requirements: Go 1.25+
 
+**Installing Go on Ubuntu/Debian:**
+```sh
+wget https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin
+```
+Add `export PATH=$PATH:/usr/local/go/bin` to your `~/.profile` or `~/.bashrc` to make it permanent.
+
 `make build` - outputs a cli binary into `bin/akavecli`.<br>
 `make test` - runs tests.<br>
 Look at `Makefile` for details.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Requirements: Go 1.25+
 > **Note:** Replace `linux-amd64` with `linux-arm64` if you are on an ARM host (run `uname -m` — if it returns `aarch64` you need the arm64 tarball).
 
 ```sh
-wget https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.25.0.linux-$(dpkg --print-architecture).tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.25.0.linux-$(dpkg --print-architecture).tar.gz
 export PATH=/usr/local/go/bin:$PATH
 ```
 Add `export PATH=/usr/local/go/bin:$PATH` to your `~/.profile` or `~/.bashrc` to make it permanent.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ Whether you're building a new integration or managing data across nodes, this SD
 Requirements: Go 1.25+
 
 **Installing Go on Ubuntu/Debian:**
+
+> **Note:** Replace `linux-amd64` with `linux-arm64` if you are on an ARM host (run `uname -m` — if it returns `aarch64` you need the arm64 tarball).
+
 ```sh
 wget https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz
-export PATH=$PATH:/usr/local/go/bin
+export PATH=/usr/local/go/bin:$PATH
 ```
-Add `export PATH=$PATH:/usr/local/go/bin` to your `~/.profile` or `~/.bashrc` to make it permanent.
+Add `export PATH=/usr/local/go/bin:$PATH` to your `~/.profile` or `~/.bashrc` to make it permanent.
 
 `make build` - outputs a cli binary into `bin/akavecli`.<br>
 `make test` - runs tests.<br>


### PR DESCRIPTION
Closes #33 

The README listed Go 1.25+ as a requirement without providing installation instructions. On Ubuntu/Debian, installing Go to /usr/local requires sudo, which was not documented.

This change adds clear Ubuntu/Debian installation steps with the correct sudo usage for system-level operations.


> Note: Tested on aws graviton instance with ubuntu image