### PR TITLE
docs: fix broken link to Blockchain Integrated SDK documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The **Akave SDK CLI** (`akavesdk`) is a command-line tool designed to streamline
 
 Whether you're building a new integration or managing data across nodes, this SDK provides robust capabilities to help you achieve seamless, scalable storage solutions.
 
+For full documentation including the Blockchain Integrated SDK guide, visit: https://docs.akave.ai/akave-sdk-cli/blockchain-integrated
+
 ```Base commit: tag v0.4.4```.
 
 ## Build and test instructions


### PR DESCRIPTION
@Abhay-2811 
<img width="1208" height="344" alt="image" src="https://github.com/user-attachments/assets/39c7190e-c98b-466a-869d-3c51dc5e3292" />

The current link to the sdk doc is broken as mentioned in #39 . I reviewed the git history of akave docs and it seems it has always been `/blockchain-integrated`. 

Closes #39 