### PR TITLE
feat: add goreleaser release pipeline and install script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,40 @@
+name: Snapshot Build
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Run GoReleaser (snapshot)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --clean --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload snapshot artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: akavecli-snapshot
+          path: ./dist/*

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -28,7 +28,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: build --clean --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ archives:
   - id: default
     format: binary
     name_template: >-
-      {{ .ProjectName }}-
+      akavecli-
       {{- .Os }}-
       {{- if eq .Arch "amd64" }}amd64
       {{- else if eq .Arch "arm64" }}arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,69 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: akavecli
+    binary: akavecli
+    main: ./cmd/akavecli/
+    ldflags:
+      - -X "github.com/akave-ai/akavesdk/private/version.tag={{.Version}}"
+      - -s -w
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: default
+    format: binary
+    name_template: >-
+      {{ .ProjectName }}-
+      {{- .Os }}-
+      {{- if eq .Arch "amd64" }}amd64
+      {{- else if eq .Arch "arm64" }}arm64
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  format: "{{.SHA}}: {{.Message}} (@{{.AuthorUsername}})"
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+
+release:
+  mode: append
+  prerelease: auto
+  header: |
+    ## Install
+
+    **Linux/macOS (one-liner):**
+    ```sh
+    curl -sSL https://raw.githubusercontent.com/akave-ai/akavesdk/main/install.sh | bash
+    ```
+
+    **Or with [eget](https://github.com/zyedidia/eget):**
+    ```sh
+    eget akave-ai/akavesdk --asset akavecli
+    ```
+
+  extra_files:
+    - glob: ./install.sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ eget akave-ai/akavesdk --asset akavecli
 
 Pre-built binaries for Linux, macOS (Intel + Apple Silicon), and Windows are available on the [Releases page](https://github.com/akave-ai/akavesdk/releases/latest).
 
-> **Manual install**: Download the binary for your platform from the Releases page. On Linux/macOS, rename it to `akavecli` and move it to a directory in your `$PATH` (e.g. `/usr/local/bin`). On Windows, keep the filename as `akavecli.exe` and place it in a directory on your `PATH`.
+> **Manual install**: Download the binary for your platform from the Releases page. On Linux/macOS, rename it to `akavecli`, make it executable (`chmod +x akavecli`), and move it to a directory in your `$PATH` (e.g. `/usr/local/bin`). On Windows, extract the `.zip` archive and add the directory containing `akavecli.exe` to your system PATH.
 
 
 ## Build and test instructions

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ eget akave-ai/akavesdk --asset akavecli
 
 Pre-built binaries for Linux, macOS (Intel + Apple Silicon), and Windows are available on the [Releases page](https://github.com/akave-ai/akavesdk/releases/latest).
 
-> **Manual install**: Download the binary for your platform from the Releases page, rename it to `akavecli`, and move it to a directory in your `$PATH` (e.g. `/usr/local/bin`).
+> **Manual install**: Download the binary for your platform from the Releases page. On Linux/macOS, rename it to `akavecli` and move it to a directory in your `$PATH` (e.g. `/usr/local/bin`). On Windows, keep the filename as `akavecli.exe` and place it in a directory on your `PATH`.
 
 
 ## Build and test instructions

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ Whether you're building a new integration or managing data across nodes, this SD
 
 ```Base commit: tag v0.4.4```.
 
+## Install
+
+The quickest way to install `akavecli` — no Go toolchain required:
+
+```sh
+curl -sSL https://raw.githubusercontent.com/akave-ai/akavesdk/main/install.sh | bash
+```
+
+Or with [eget](https://github.com/zyedidia/eget):
+
+```sh
+eget akave-ai/akavesdk --asset akavecli
+```
+
+Pre-built binaries for Linux, macOS (Intel + Apple Silicon), and Windows are available on the [Releases page](https://github.com/akave-ai/akavesdk/releases/latest).
+
+> **Manual install**: Download the binary for your platform from the Releases page, rename it to `akavecli`, and move it to a directory in your `$PATH` (e.g. `/usr/local/bin`).
+
+
 ## Build and test instructions
 Requirements: Go 1.25+
 

--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,7 @@ install_akavecli() {
     echo "Downloading ${BINARY_NAME} ${version} (${OS}/${ARCH})..."
 
     if [ "$HTTP_CLI" = "curl" ]; then
-        curl -sSL -o "$tmp" "$url" || { echo "Download failed: $url" >&2; rm -f "$tmp"; exit 1; }
+        curl -fsSL -o "$tmp" "$url" || { echo "Download failed: $url" >&2; rm -f "$tmp"; exit 1; }
     else
         wget -q -O "$tmp" "$url" || { echo "Download failed: $url" >&2; rm -f "$tmp"; exit 1; }
     fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# shellcheck shell=dash
+# Install akavecli — the Akave SDK CLI
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/akave-ai/akavesdk/main/install.sh | bash
+#
+# Overrides (env vars):
+#   AKAVECLI_VERSION=v0.4.4   install a specific version
+#   INSTALL_DIR=/usr/local/bin install location (default: /usr/local/bin)
+#   GITHUB_ORG=akave-ai        GitHub org (override for forks)
+
+set -eu
+
+GITHUB_ORG=${GITHUB_ORG:-"akave-ai"}
+GITHUB_REPO=${GITHUB_REPO:-"akavesdk"}
+BINARY_NAME="akavecli"
+INSTALL_DIR=${INSTALL_DIR:-"/usr/local/bin"}
+HTTP_CLI=${HTTP_CLI:-"curl"}
+version=${AKAVECLI_VERSION:-""}
+
+get_latest_release() {
+    local release_url="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest"
+
+    if [ "$HTTP_CLI" = "curl" ]; then
+        version=$(curl -s "$release_url" | grep '"tag_name"' | grep -Eo '"v[^"]+"' | head -1 | tr -d '"')
+    else
+        version=$(wget -q -O - "$release_url" | grep '"tag_name"' | grep -Eo '"v[^"]+"' | head -1 | tr -d '"')
+    fi
+
+    if [ -z "$version" ]; then
+        echo "Error: could not determine latest release." >&2
+        echo "Set AKAVECLI_VERSION to install a specific version, e.g.:" >&2
+        echo "  AKAVECLI_VERSION=v0.4.4 curl -sSL ... | bash" >&2
+        exit 1
+    fi
+
+    echo "Latest release: $version"
+}
+
+detect_platform() {
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64|amd64)  ARCH="amd64" ;;
+        aarch64|arm64) ARCH="arm64" ;;
+        *)
+            echo "Unsupported architecture: $ARCH" >&2
+            exit 1
+            ;;
+    esac
+
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$OS" in
+        linux|darwin) ;;
+        *)
+            echo "Unsupported OS: $OS" >&2
+            echo "For Windows, download from: https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest" >&2
+            exit 1
+            ;;
+    esac
+
+    export ARCH OS
+}
+
+install_akavecli() {
+    if [ -z "$version" ]; then
+        get_latest_release
+    fi
+
+    local asset="${BINARY_NAME}-${OS}-${ARCH}"
+    local url="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${version}/${asset}"
+    local tmp
+    tmp=$(mktemp)
+
+    echo "Downloading ${BINARY_NAME} ${version} (${OS}/${ARCH})..."
+
+    if [ "$HTTP_CLI" = "curl" ]; then
+        curl -sSL -o "$tmp" "$url" || { echo "Download failed: $url" >&2; rm -f "$tmp"; exit 1; }
+    else
+        wget -q -O "$tmp" "$url" || { echo "Download failed: $url" >&2; rm -f "$tmp"; exit 1; }
+    fi
+
+    chmod +x "$tmp"
+
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "$tmp" "${INSTALL_DIR}/${BINARY_NAME}"
+    else
+        echo "Requires elevated permissions to install to ${INSTALL_DIR}..."
+        sudo mv "$tmp" "${INSTALL_DIR}/${BINARY_NAME}"
+    fi
+
+    if command -v "$BINARY_NAME" >/dev/null 2>&1; then
+        echo ""
+        echo "akavecli installed to ${INSTALL_DIR}/${BINARY_NAME}"
+        echo "Run 'akavecli --help' to get started."
+        echo "Docs: https://docs.akave.ai"
+    else
+        echo "Installed to ${INSTALL_DIR}/${BINARY_NAME}. Ensure ${INSTALL_DIR} is in your PATH."
+    fi
+}
+
+detect_platform
+install_akavecli

--- a/private/version/version.go
+++ b/private/version/version.go
@@ -9,15 +9,21 @@ import (
 	"runtime/debug"
 )
 
+// tag is set at build time via goreleaser ldflags:
+//
+//	-X "github.com/akave-ai/akavesdk/private/version.tag=v0.4.4"
+var tag = "dev"
+
 // Version encapsulates minimal version information.
 type Version struct {
+	Tag       string
 	Commit    string
 	Timestamp string
 }
 
 // Format formats version for CLI output.
 func (v Version) Format() string {
-	return fmt.Sprintf("commit: %s\ntimestamp: %s\n", v.Commit, v.Timestamp)
+	return fmt.Sprintf("version: %s\ncommit: %s\ntimestamp: %s\n", v.Tag, v.Commit, v.Timestamp)
 }
 
 // Info retrieves process version.
@@ -39,6 +45,7 @@ func Info() Version {
 	}
 
 	return Version{
+		Tag:       tag,
 		Commit:    commit,
 		Timestamp: timestamp,
 	}


### PR DESCRIPTION
## Summary

Currently the only way to get `akavecli` is to build from source, which requires Go 1.25+ and adds friction for anyone who just wants to use the CLI. This PR adds a production-grade release pipeline.

Closes #63 

## What's added

**.goreleaser.yaml** - Builds `akavecli` for Linux, macOS (amd64 + arm64), and Windows (amd64) with CGO_ENABLED=0 for fully static binaries. Injects the release tag via ldflags.

**.github/workflows/release.yml** - Triggers goreleaser on v* tag pushes to create a GitHub Release with pre-built binaries.

**.github/workflows/snapshot.yml** - Snapshot build on every push to main to keep the pipeline green.

**install.sh** - One-liner install script. Auto-detects OS/arch, downloads the correct binary. Supports AKAVECLI_VERSION, INSTALL_DIR, and GITHUB_ORG overrides.

**private/version/version.go** - Adds a tag variable injected by goreleaser ldflags so akavecli version shows the release tag instead of dev.

**README.md** - Adds an Install section with the one-liner and eget methods.

## Testing on this fork

Push a test tag to trigger the release workflow:
  `git tag v0.0.1-test && git push origin v0.0.1-test`

Test the install script against this fork:
  `GITHUB_ORG=ideo-org AKAVECLI_VERSION=v0.5.0-alpha curl -sSL https://raw.githubusercontent.com/ideo-org/akavesdk/feat/goreleaser-releases/install.sh | bash`